### PR TITLE
fix: budget lost-update race and DNS-rebinding SSRF (v1.8.5)

### DIFF
--- a/core/webhooks.py
+++ b/core/webhooks.py
@@ -71,15 +71,13 @@ _PRIVATE_NETWORKS = [
 
 
 def _validate_webhook_url(url: str) -> None:
-    """Raise ValueError if url targets a private/internal network (SSRF guard).
+    """Raise ValueError if url is structurally invalid or targets a private IP literal.
 
-    Checks:
-      1. Scheme must be http or https — blocks file://, gopher://, etc.
-      2. Host must be present.
-      3. If host is an IP literal, it must not fall in a private/reserved range.
-      4. If host is a hostname, it is resolved synchronously (cached by the OS
-         resolver) and the resulting IP is checked.  DNS failure is fail-open to
-         avoid blocking legitimate webhooks on transient DNS errors.
+    This is a *load-time* structural check only — it catches obvious mistakes
+    (wrong scheme, bare IP targeting internal ranges) but does NOT prevent DNS
+    rebinding for hostname-based URLs.  The actual runtime SSRF guard is
+    _SSRFBlockingResolver, which validates the resolved IP at aiohttp connect
+    time, after every DNS lookup, preventing rebinding attacks.
     """
     try:
         parsed = urllib.parse.urlparse(url)
@@ -93,30 +91,56 @@ def _validate_webhook_url(url: str) -> None:
     if not host:
         raise ValueError("Webhook URL has no host")
 
-    # Try host as an IP literal first (no DNS needed)
+    # Only check IP literals here — no DNS resolution (TOCTOU / DNS rebinding risk).
+    # Hostname-based URLs are validated by _SSRFBlockingResolver at connect time.
     try:
         ip = ipaddress.ip_address(host)
         for net in _PRIVATE_NETWORKS:
             if ip in net:
                 raise ValueError(f"Webhook URL targets private/reserved IP {ip}")
-        return
     except ValueError as exc:
-        # Re-raise SSRF-specific errors; otherwise host is a hostname, continue
         if "private/reserved" in str(exc):
             raise
+        # Not an IP literal — hostname validation deferred to _SSRFBlockingResolver
 
-    # Hostname — resolve to IP and validate (blocking; webhooks are rare events)
-    try:
-        resolved = socket.gethostbyname(host)
-        ip = ipaddress.ip_address(resolved)
-        for net in _PRIVATE_NETWORKS:
-            if ip in net:
-                raise ValueError(
-                    f"Webhook URL host '{host}' resolves to private/reserved IP {ip}"
-                )
-    except OSError:
-        # DNS failure — fail-open (don't block on transient resolver errors)
-        pass
+
+class _SSRFBlockingResolver(aiohttp.abc.AbstractResolver):
+    """aiohttp resolver that validates resolved IPs against private CIDR ranges.
+
+    By plugging into the TCPConnector, this check runs at the moment aiohttp
+    resolves a hostname before opening a TCP socket — AFTER every DNS lookup.
+    This prevents DNS rebinding: an attacker cannot serve a public IP during
+    _validate_webhook_url() at load time and a private IP at request time,
+    because we re-check every time a connection is established.
+
+    Fail-closed: DNS failures propagate as OSError → aiohttp raises
+    ClientConnectorError, the webhook delivery fails, and the exception is
+    logged.  We never silently allow an unresolved hostname through.
+    """
+
+    def __init__(self) -> None:
+        self._resolver = aiohttp.resolver.DefaultResolver()
+
+    async def resolve(
+        self, hostname: str, port: int = 0, family: int = socket.AF_INET
+    ) -> list:
+        # DNS failure propagates here — fail-closed by default (no except)
+        addrs = await self._resolver.resolve(hostname, port, family)
+        for addr in addrs:
+            try:
+                ip = ipaddress.ip_address(addr["host"])
+            except ValueError:
+                continue
+            for net in _PRIVATE_NETWORKS:
+                if ip in net:
+                    raise OSError(
+                        f"SSRF blocked: {hostname!r} resolved to "
+                        f"private/reserved IP {ip} ({net})"
+                    )
+        return addrs
+
+    async def close(self) -> None:
+        await self._resolver.close()
 
 
 # Minimum interval between identical events (debounce)
@@ -170,8 +194,12 @@ class WebhookDispatcher:
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
+            # _SSRFBlockingResolver validates the resolved IP at connect time,
+            # preventing DNS rebinding attacks that bypass load-time URL checks.
+            connector = aiohttp.TCPConnector(resolver=_SSRFBlockingResolver())
             self._session = aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=10)
+                connector=connector,
+                timeout=aiohttp.ClientTimeout(total=10),
             )
         return self._session
 

--- a/proxy/forwarder.py
+++ b/proxy/forwarder.py
@@ -176,7 +176,6 @@ class RequestForwarder:
         ttft_start = time.perf_counter()
         first_chunk_seen = False
         circuit_success_reported = False
-        budget_lock = self._budget_lock
         # cost_ref is passed per-request — never shared across concurrent requests
         if cost_ref is None:
             cost_ref = {}
@@ -255,8 +254,10 @@ class RequestForwarder:
                     c_tok = stream_usage.get("completion_tokens") or stream_usage.get("candidatesTokenCount", 0)
                     model_name = ctx.body.get("model", "")
                     real_cost = estimate_cost(model_name, p_tok, c_tok)
-                    async with budget_lock:
-                        cost_ref["total"] = cost_ref.get("total", 0.0) + real_cost
+                    # Accumulate only the delta for this request; the rotator
+                    # adds it atomically under budget_lock. No lock needed here
+                    # because cost_ref is per-request and not shared.
+                    cost_ref["delta"] = cost_ref.get("delta", 0.0) + real_cost
                     ctx.metadata["_stream_usage"] = {"prompt_tokens": p_tok, "completion_tokens": c_tok}
                     ctx.metadata["_stream_cost_usd"] = round(real_cost, 6)
 

--- a/proxy/rotator.py
+++ b/proxy/rotator.py
@@ -408,15 +408,15 @@ class RotatorAgent(BaseAgent):
             # Forward request with cross-provider fallback
             start_req = time.time()
             session = await self._get_session()
-            # Per-request cost dict: isolated from concurrent requests so
-            # concurrent streams cannot overwrite each other's budget reference.
-            async with self._budget_lock:
-                cost_ref: dict[str, float] = {"total": self.total_cost_today}
+            # Per-request delta dict: forwarder accumulates only the cost
+            # increment for this request; rotator adds it atomically under
+            # budget_lock, preventing lost-update when concurrent streams
+            # each started from the same total_cost_today snapshot.
+            cost_ref: dict[str, float] = {"delta": 0.0}
             await self.forwarder.forward_with_fallback(ctx, target, headers, session,
                                                        cost_ref=cost_ref)
-            # Sync back real token cost from streaming (if updated)
             async with self._budget_lock:
-                self.total_cost_today = cost_ref.get("total", self.total_cost_today)
+                self.total_cost_today += cost_ref["delta"]
 
             ctx.metadata["duration"] = time.time() - start_req
 


### PR DESCRIPTION
## Summary

- **Lost-update on daily budget** (`proxy/rotator.py`, `proxy/forwarder.py`): the v1.8.4 cost isolation fix introduced a lost-update: concurrent requests each snapshotted the same `total_cost_today`, so the last stream to finish silently overwrote all prior charges. Fixed by switching to a `{"delta": 0.0}` pattern — forwarder accumulates only the increment for its own request; rotator atomically adds it under `budget_lock` (`total_cost_today += cost_ref["delta"]`)
- **DNS rebinding SSRF** (`core/webhooks.py`): the load-time `socket.gethostbyname()` check was TOCTOU — attacker serves a public IP during validation, then re-resolves to `169.254.169.254` at request time. `except OSError: pass` was also fail-open. Fixed with `_SSRFBlockingResolver`: a custom `aiohttp.abc.AbstractResolver` that validates every resolved IP against `_PRIVATE_NETWORKS` at the moment aiohttp opens the TCP socket, after every DNS lookup. DNS failures propagate (fail-closed). `_validate_webhook_url()` retained for load-time scheme + IP-literal checks only

## Test plan

- [ ] `pytest tests/ --ignore=tests/integrated_test.py` — 870 passed
- [ ] Simulate concurrent streams: verify `total_cost_today` accumulates all deltas, none lost
- [ ] Verify SSRF resolver rejects `169.254.169.254`, `10.0.0.1`, `::1` at connect time
- [ ] Verify DNS failure → `ClientConnectorError` (fail-closed), not silent pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)