### PR TITLE
fix: WASM threading lock, plugin path traversal, blocking RBAC SQLite (v1.9.1)

### DIFF
--- a/core/plugin_engine.py
+++ b/core/plugin_engine.py
@@ -375,6 +375,16 @@ class PluginManager:
             module_path, target_name = entrypoint.split(":")
             file_path = os.path.join(self.plugins_dir, f"{module_path.replace('.', '/')}.py")
 
+            # Directory traversal guard: os.path.join silently discards the
+            # base directory when the second argument is an absolute path
+            # (e.g. os.path.join("plugins", "/tmp/evil.py") → "/tmp/evil.py").
+            # Resolve both paths and verify containment before proceeding.
+            safe_base = os.path.abspath(self.plugins_dir) + os.sep
+            if not os.path.abspath(file_path).startswith(safe_base):
+                raise ValueError(
+                    f"Plugin path traversal detected: '{file_path}' escapes plugins_dir"
+                )
+
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"Plugin file not found: {file_path}")
 
@@ -420,6 +430,11 @@ class PluginManager:
 
         elif p_type == "wasm":
             file_path = os.path.join(self.plugins_dir, f"{entrypoint.replace('.', '/')}.wasm")
+            safe_base = os.path.abspath(self.plugins_dir) + os.sep
+            if not os.path.abspath(file_path).startswith(safe_base):
+                raise ValueError(
+                    f"Plugin path traversal detected: '{file_path}' escapes plugins_dir"
+                )
             if not os.path.exists(file_path):
                 raise FileNotFoundError(f"WASM plugin not found: {file_path}")
 

--- a/core/rbac.py
+++ b/core/rbac.py
@@ -138,9 +138,13 @@ class RBACManager:
             )
             conn.commit()
 
-    def set_user_roles(self, subject: str, email: Optional[str], roles: List[str]):
-        """Persist user->role mapping."""
-        self._sync_set_user_roles(subject, email, roles)
+    async def set_user_roles(self, subject: str, email: Optional[str], roles: List[str]):
+        """Persist user->role mapping (non-blocking).
+
+        Runs the SQLite write in a thread-pool worker — calling sqlite3 directly
+        on the asyncio event loop stalls ALL concurrent requests.
+        """
+        await asyncio.to_thread(self._sync_set_user_roles, subject, email, roles)
 
     def _sync_get_user_roles(self, subject: str) -> List[str]:
         with sqlite3.connect(self.db_path) as conn:
@@ -152,6 +156,6 @@ class RBACManager:
                 return [r.strip() for r in row[0].split(",") if r.strip()]
         return ["user"]
 
-    def get_user_roles(self, subject: str) -> List[str]:
-        """Look up persisted roles for a user subject."""
-        return self._sync_get_user_roles(subject)
+    async def get_user_roles(self, subject: str) -> List[str]:
+        """Look up persisted roles for a user subject (non-blocking)."""
+        return await asyncio.to_thread(self._sync_get_user_roles, subject)

--- a/core/wasm_runner.py
+++ b/core/wasm_runner.py
@@ -40,6 +40,7 @@ Usage:
 import json
 import asyncio
 import logging
+import threading
 import concurrent.futures
 from typing import Dict, Any, Optional
 
@@ -83,12 +84,21 @@ class WasmRunner:
         self._plugin = None  # Extism Plugin instance
         self._loaded = False
         self.logger = logging.getLogger(f"wasm.{wasm_path.split('/')[-1]}")
-        # Extism Plugin objects are NOT thread-safe: concurrent calls to
-        # _plugin.call() on the same instance corrupt the WASM linear memory
-        # and can cross-contaminate data between requests (cross-tenant leak)
-        # or crash the process via SIGSEGV. Serialise all execute() calls for
-        # this plugin instance with a per-runner asyncio.Lock.
-        self._exec_lock = asyncio.Lock()
+        # threading.Lock (NOT asyncio.Lock): the lock must be held at the
+        # native-thread level, not the coroutine level.
+        #
+        # asyncio.Lock is released when the awaiting coroutine is cancelled
+        # (e.g. asyncio.wait_for timeout), but the underlying thread submitted
+        # via run_in_executor keeps running.  If the asyncio.Lock were released
+        # on cancellation, a new coroutine could acquire it and launch a second
+        # thread — both threads would then call self._plugin.call() concurrently
+        # on the same Extism instance, corrupting WASM linear memory (SIGSEGV /
+        # cross-tenant data leak).
+        #
+        # threading.Lock is acquired INSIDE _sync_call (the thread itself), so
+        # it stays held until the thread finishes regardless of what happens to
+        # the asyncio coroutine above it.
+        self._exec_lock = threading.Lock()
 
     async def load(self) -> bool:
         """
@@ -141,14 +151,13 @@ class WasmRunner:
         input_json = json.dumps(input_data)
 
         try:
-            # Serialise calls: the Extism Plugin instance is not thread-safe.
-            # The lock ensures only one coroutine calls into the native WASM
-            # runtime at a time for this plugin, preventing memory corruption.
-            async with self._exec_lock:
-                loop = asyncio.get_event_loop()
-                result_bytes = await loop.run_in_executor(
-                    _WASM_EXECUTOR, self._sync_call, input_json
-                )
+            # Delegate to thread pool; _sync_call acquires the threading.Lock
+            # internally so that concurrent or cancelled coroutines cannot
+            # trigger simultaneous calls into the Extism runtime.
+            loop = asyncio.get_event_loop()
+            result_bytes = await loop.run_in_executor(
+                _WASM_EXECUTOR, self._sync_call, input_json
+            )
             return self._parse_result(result_bytes)
 
         except Exception as e:
@@ -156,10 +165,18 @@ class WasmRunner:
             return PluginResponse.passthrough()
 
     def _sync_call(self, input_json: str) -> Optional[bytes]:
-        """Synchronous WASM call (runs in thread pool)."""
-        if self._plugin is None:
-            raise RuntimeError("WASM plugin not loaded — call load() first")
-        return self._plugin.call("handle", input_json.encode("utf-8"))
+        """Synchronous WASM call (runs in thread pool).
+
+        Acquires self._exec_lock (a threading.Lock) before calling into the
+        Extism runtime.  This serialises concurrent threads at the native level:
+        even if the asyncio coroutine above is cancelled (e.g. wait_for timeout)
+        and the asyncio machinery moves on, this thread holds the lock until it
+        returns, so no other thread can enter the Extism plugin simultaneously.
+        """
+        with self._exec_lock:
+            if self._plugin is None:
+                raise RuntimeError("WASM plugin not loaded — call load() first")
+            return self._plugin.call("handle", input_json.encode("utf-8"))
 
     def _parse_result(self, result_bytes: Optional[bytes]) -> PluginResponse:
         """

--- a/proxy/routes/chat.py
+++ b/proxy/routes/chat.py
@@ -50,7 +50,7 @@ def create_router(agent) -> APIRouter:
                 request.state.roles = identity.roles
                 if not agent.rbac.check_permission(identity.roles, "proxy:use"):
                     raise HTTPException(status_code=403, detail="Insufficient permissions")
-                agent.rbac.set_user_roles(identity.subject, identity.email, identity.roles)
+                await agent.rbac.set_user_roles(identity.subject, identity.email, identity.roles)
                 await agent._add_log(
                     f"IDENTITY: {identity.provider} user={identity.email or identity.subject} roles={identity.roles}",
                     level="SECURITY"

--- a/proxy/routes/identity.py
+++ b/proxy/routes/identity.py
@@ -70,7 +70,7 @@ def create_router(agent) -> APIRouter:
             raise HTTPException(status_code=401, detail="Unrecognized JWT provider")
         ttl = agent.config.get("identity", {}).get("session_ttl", 3600)
         proxy_token = agent.identity.generate_proxy_jwt(identity, ttl=ttl)
-        agent.rbac.set_user_roles(identity.subject, identity.email, identity.roles)
+        await agent.rbac.set_user_roles(identity.subject, identity.email, identity.roles)
         return {
             "token": proxy_token,
             "expires_in": ttl,

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -45,8 +45,8 @@ async def test_quota_exceeded(rbac):
     assert await rbac.check_quota("team-a-key") is False
 
 
-def test_set_get_user_roles(rbac):
-    # set_user_roles(subject, email, roles)
-    rbac.set_user_roles("sub-123", "user@test.com", ["admin", "operator"])
-    roles = rbac.get_user_roles("sub-123")
+@pytest.mark.asyncio
+async def test_set_get_user_roles(rbac):
+    await rbac.set_user_roles("sub-123", "user@test.com", ["admin", "operator"])
+    roles = await rbac.get_user_roles("sub-123")
     assert set(roles) == {"admin", "operator"}


### PR DESCRIPTION
## Summary

- **WASM sandbox escape / memory corruption** (`core/wasm_runner.py`): `asyncio.Lock` is released when a coroutine is cancelled by `asyncio.wait_for` timeout, but the underlying thread in `run_in_executor` keeps running. A second coroutine can then acquire the lock and launch another thread — both threads call `self._plugin.call()` concurrently on the same Extism instance, corrupting WASM linear memory (SIGSEGV / cross-tenant data leak). Fixed by replacing `asyncio.Lock` with `threading.Lock` acquired **inside `_sync_call`** (the thread itself), so the lock is held until the thread returns regardless of what the asyncio coroutine does

- **Plugin directory traversal** (`core/plugin_engine.py`): `os.path.join(plugins_dir, user_supplied)` silently discards the base directory when the second argument is absolute (e.g. `os.path.join("plugins", "/tmp/evil.py")` → `/tmp/evil.py`). Added `os.path.abspath` containment check for both Python and WASM plugin paths before any file I/O or import

- **Blocking SQLite on event loop** (`core/rbac.py`, callers): `set_user_roles` was called synchronously on the asyncio event loop for every authenticated request (hot path in `chat.py`), blocking all concurrent requests during the SQLite write. Made `set_user_roles` and `get_user_roles` async via `asyncio.to_thread`; updated callers in `chat.py` and `identity.py`

## Rejected (false positive)
- Cache NFKC poisoning: `json.dumps` defaults to `ensure_ascii=True` — non-ASCII chars are escaped as `\uXXXX` before NFKC normalization, which is then a no-op on the resulting ASCII string

## Test plan
- [ ] `pytest tests/ --ignore=tests/integrated_test.py` — 870 passed
- [ ] Verify WASM lock held under timeout: simulate slow plugin + wait_for → second request queues, does not enter plugin simultaneously
- [ ] Verify plugin traversal: entrypoint `/tmp/x:func` raises ValueError, never loads file
- [ ] Verify RBAC: `set_user_roles` / `get_user_roles` return correct results as async

🤖 Generated with [Claude Code](https://claude.com/claude-code)