### PR TITLE
fix: auth on plugin/GDPR endpoints, JSON injection in GDPR audit (v1.9.2)

### DIFF
--- a/proxy/routes/gdpr.py
+++ b/proxy/routes/gdpr.py
@@ -8,9 +8,10 @@ Endpoints:
   POST /api/v1/gdpr/purge              — Manual trigger: purge expired records
 """
 
+import json
 import time
 import logging
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Request, HTTPException
 
 logger = logging.getLogger("llmproxy.routes.gdpr")
 
@@ -18,8 +19,24 @@ logger = logging.getLogger("llmproxy.routes.gdpr")
 def create_router(agent) -> APIRouter:
     router = APIRouter()
 
+    def _check_admin_auth(request: Request):
+        """Enforce API key auth on GDPR mutating endpoints.
+
+        Unauthenticated access to erase/export allows any caller to delete or
+        exfiltrate all subject data without a trace.  Auth is skipped only when
+        explicitly disabled (development mode).
+        """
+        if not agent.config.get("server", {}).get("auth", {}).get("enabled", False):
+            return
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header.replace("Bearer ", "").strip()
+        valid_keys = agent._get_api_keys()
+        if not token or token not in valid_keys:
+            raise HTTPException(status_code=401, detail="GDPR: Unauthorized")
+
     @router.post("/api/v1/gdpr/erase/{subject}")
-    async def erase_subject(subject: str):
+    async def erase_subject(subject: str, request: Request):
+        _check_admin_auth(request)
         """Right to erasure (GDPR Article 17).
 
         Deletes all audit_log, spend_log, and user_roles entries
@@ -32,7 +49,14 @@ def create_router(agent) -> APIRouter:
         if total_deleted == 0:
             raise HTTPException(status_code=404, detail=f"No data found for subject '{subject}'")
 
-        # Immutable audit of the erasure itself (GDPR requires this)
+        # Immutable audit of the erasure itself (GDPR requires this).
+        # Use json.dumps — never interpolate subject directly into a JSON string
+        # (subject may contain quotes/braces that break JSON structure).
+        audit_meta = json.dumps({
+            "action": "erase",
+            "subject": subject,
+            "deleted": total_deleted,
+        }, separators=(",", ":"))
         await agent.store.log_audit(
             ts=int(time.time()),
             req_id=f"gdpr-erase-{subject[:16]}",
@@ -47,7 +71,7 @@ def create_router(agent) -> APIRouter:
             latency_ms=0.0,
             blocked=False,
             block_reason="",
-            metadata=f'{{"action":"erase","subject":"{subject}","deleted":{total_deleted}}}',
+            metadata=audit_meta,
         )
 
         logger.info(f"GDPR erasure: subject='{subject}' deleted={result}")
@@ -58,7 +82,8 @@ def create_router(agent) -> APIRouter:
         }
 
     @router.get("/api/v1/gdpr/export/{subject}")
-    async def export_subject(subject: str):
+    async def export_subject(subject: str, request: Request):
+        _check_admin_auth(request)
         """Data Subject Access Request (GDPR Article 15).
 
         Returns all data associated with the subject, scrubbed of

--- a/proxy/routes/plugins.py
+++ b/proxy/routes/plugins.py
@@ -7,6 +7,22 @@ from fastapi import APIRouter, Request, HTTPException
 def create_router(agent) -> APIRouter:
     router = APIRouter()
 
+    def _check_admin_auth(request: Request):
+        """Enforce API key auth on all plugin management endpoints.
+
+        Plugin operations (install, toggle, uninstall, hot-swap, rollback) are
+        privileged mutating actions.  Without auth enforcement an unauthenticated
+        attacker can install arbitrary code or disable security plugins.
+        Mirrors the pattern in admin.py — skipped only when auth is disabled.
+        """
+        if not agent.config.get("server", {}).get("auth", {}).get("enabled", False):
+            return  # Auth disabled — development mode, allow all
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header.replace("Bearer ", "").strip()
+        valid_keys = agent._get_api_keys()
+        if not token or token not in valid_keys:
+            raise HTTPException(status_code=401, detail="Plugins: Unauthorized")
+
     @router.get("/api/v1/plugins")
     async def get_plugins():
         import os
@@ -21,6 +37,7 @@ def create_router(agent) -> APIRouter:
 
     @router.post("/api/v1/plugins/toggle")
     async def toggle_plugin(request: Request):
+        _check_admin_auth(request)
         data = await request.json()
         plugin_name = data.get("name")
         enabled = data.get("enabled")
@@ -41,6 +58,7 @@ def create_router(agent) -> APIRouter:
 
     @router.post("/api/v1/plugins/install")
     async def install_plugin(request: Request):
+        _check_admin_auth(request)
         data = await request.json()
         required = {"name", "hook", "entrypoint"}
         if not required.issubset(data.keys()):
@@ -53,7 +71,8 @@ def create_router(agent) -> APIRouter:
             raise HTTPException(status_code=422, detail=str(e))
 
     @router.delete("/api/v1/plugins/{plugin_name}")
-    async def uninstall_plugin(plugin_name: str):
+    async def uninstall_plugin(plugin_name: str, request: Request):
+        _check_admin_auth(request)
         removed = await agent.plugin_manager.uninstall_plugin(plugin_name)
         if not removed:
             raise HTTPException(status_code=404, detail=f"Plugin '{plugin_name}' not found")
@@ -65,7 +84,8 @@ def create_router(agent) -> APIRouter:
         return agent.plugin_manager.get_plugin_stats()
 
     @router.post("/api/v1/plugins/hot-swap")
-    async def hot_swap_plugins():
+    async def hot_swap_plugins(request: Request):
+        _check_admin_auth(request)
         try:
             await agent.plugin_manager.hot_swap()
             return {"status": "success", "message": "Plugin DAG reloaded"}
@@ -73,7 +93,8 @@ def create_router(agent) -> APIRouter:
             return {"status": "rolled_back", "error": str(e)}
 
     @router.post("/api/v1/plugins/rollback")
-    async def rollback_plugins():
+    async def rollback_plugins(request: Request):
+        _check_admin_auth(request)
         await agent.plugin_manager.rollback()
         return {"status": "rolled_back"}
 


### PR DESCRIPTION
## Summary

### Critical — Unauthenticated plugin management endpoints (`proxy/routes/plugins.py`)
`toggle`, `install`, `uninstall`, `hot-swap`, `rollback` had zero auth checks. With `auth.enabled=true`, every other admin endpoint calls `_check_admin_auth()` — plugin routes skipped it entirely. Any unauthenticated caller could install arbitrary code, disable security plugins, or trigger hot-swaps. Added `_check_admin_auth()` to all 5 mutating endpoints. GET (read-only listing) remains open.

### Critical — Unauthenticated GDPR erase/export (`proxy/routes/gdpr.py`)
`POST /api/v1/gdpr/erase/{subject}` and `GET /api/v1/gdpr/export/{subject}` had no auth check — any caller could delete or exfiltrate all personal data for any subject. Added `_check_admin_auth()` to both.

### High — JSON injection in GDPR audit log metadata (`proxy/routes/gdpr.py`)
The erasure audit record used an f-string to build JSON: `` f'{"action":"erase","subject":"{subject}","deleted":{total_deleted}}' ``. A subject containing `"` or `}` (e.g. from a URL path) would produce malformed JSON or inject arbitrary fields into the immutable audit log. Fixed with `json.dumps()`.

## Rejected (false positives)
- ThreatLedger race condition: asyncio is single-threaded cooperative — `_record_and_check` has no `await` so runs atomically from the event loop's perspective
- Timing attack on API key comparison: theoretical at network latency levels; logged for future work

## Test plan
- [ ] `pytest tests/ --ignore=tests/integrated_test.py` — 870 passed
- [ ] With auth enabled: verify plugin endpoints return 401 without Bearer token
- [ ] With auth disabled: verify plugin endpoints still work (dev mode)
- [ ] Verify GDPR erase with subject=`foo"bar` produces valid JSON in audit log

🤖 Generated with [Claude Code](https://claude.com/claude-code)