### PR TITLE
fix: auth on registry/telemetry endpoints, PII scrubber, OTLP TLS (v1.9.3)

### DIFF
--- a/core/export.py
+++ b/core/export.py
@@ -28,10 +28,23 @@ logger = logging.getLogger(__name__)
 PII_PATTERNS = [
     (re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'), '<EMAIL>'),
     (re.compile(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b'), '<IP>'),
+    # API keys: OpenAI (sk-...), Anthropic (sk-ant-...), generic long secrets
+    (re.compile(r'sk-ant-[a-zA-Z0-9_\-]{20,}'), '<API_KEY>'),
     (re.compile(r'sk-[a-zA-Z0-9]{20,}'), '<API_KEY>'),
     (re.compile(r'Bearer\s+[a-zA-Z0-9._\-]+'), 'Bearer <REDACTED>'),
     (re.compile(r'eyJ[a-zA-Z0-9_\-]+\.eyJ[a-zA-Z0-9_\-]+\.[a-zA-Z0-9_\-]+'), '<JWT>'),
 ]
+
+# Sensitive field names (matched case-insensitively in scrub_dict).
+# Covers common variations used by providers, frameworks, and reverse proxies.
+_SENSITIVE_FIELDS = frozenset({
+    'authorization', 'api_key', 'apikey', 'api-key',
+    'token', 'access_token', 'refresh_token', 'id_token',
+    'password', 'passwd',
+    'secret', 'client_secret', 'secret_key', 'signing_key', 'private_key',
+    'credentials', 'credential',
+    'x-api-key', 'x-auth-token', 'x-access-token',
+})
 
 
 def scrub_pii(text: str) -> str:
@@ -45,8 +58,8 @@ def scrub_dict(d: Dict[str, Any]) -> Dict[str, Any]:
     """Recursively scrub PII from a dictionary."""
     result: Dict[str, Any] = {}
     for k, v in d.items():
-        # Skip known sensitive fields entirely
-        if k.lower() in ('authorization', 'api_key', 'token', 'password', 'secret'):
+        # Redact known sensitive fields regardless of value type
+        if k.lower() in _SENSITIVE_FIELDS:
             result[k] = '<REDACTED>'
         elif isinstance(v, str):
             result[k] = scrub_pii(v)

--- a/core/tracing.py
+++ b/core/tracing.py
@@ -50,7 +50,12 @@ class TraceManager:
 
         # OTLP Exporter (If endpoint provided)
         if otlp_endpoint:
-            otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
+            # Use insecure (plaintext gRPC) only for local collectors.
+            # Remote OTLP endpoints receive span data that may include auth
+            # headers and user identifiers — enforce TLS for all non-local targets.
+            _local_prefixes = ("localhost:", "127.0.0.1:", "::1:")
+            _insecure = any(otlp_endpoint.startswith(p) for p in _local_prefixes)
+            otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=_insecure)
             provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
             logger.info(f"OTLP Exporter initialized for endpoint: {otlp_endpoint}")
 

--- a/proxy/routes/registry.py
+++ b/proxy/routes/registry.py
@@ -7,8 +7,27 @@ from models import EndpointStatus
 def create_router(agent) -> APIRouter:
     router = APIRouter()
 
+    def _check_admin_auth(request: Request):
+        """Enforce API key auth on all registry mutating endpoints.
+
+        Toggle, delete, and priority changes directly affect which upstream
+        providers the proxy uses and are equivalent in impact to admin operations.
+        Without auth enforcement an unauthenticated attacker can disable all
+        endpoints (instant DoS) or redirect traffic to a malicious provider.
+        Mirrors the pattern in admin.py and plugins.py — skipped only when
+        auth is explicitly disabled (development mode).
+        """
+        if not agent.config.get("server", {}).get("auth", {}).get("enabled", False):
+            return
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header.replace("Bearer ", "").strip()
+        valid_keys = agent._get_api_keys()
+        if not token or token not in valid_keys:
+            raise HTTPException(status_code=401, detail="Registry: Unauthorized")
+
     @router.post("/api/v1/registry/{endpoint_id}/toggle")
-    async def toggle_endpoint(endpoint_id: str):
+    async def toggle_endpoint(endpoint_id: str, request: Request):
+        _check_admin_auth(request)
         all_endpoints = await agent.store.get_all()
         target = next((e for e in all_endpoints if e.id == endpoint_id), None)
         if not target:
@@ -24,6 +43,7 @@ def create_router(agent) -> APIRouter:
 
     @router.get("/api/v1/telemetry/stream")
     async def telemetry_stream(request: Request):
+        _check_admin_auth(request)
         """Real-time SSE stream for the SOC dashboard."""
         import asyncio
         import json
@@ -49,13 +69,15 @@ def create_router(agent) -> APIRouter:
         return StreamingResponse(event_generator(), media_type="text/event-stream")
 
     @router.delete("/api/v1/registry/{endpoint_id}")
-    async def delete_endpoint(endpoint_id: str):
+    async def delete_endpoint(endpoint_id: str, request: Request):
+        _check_admin_auth(request)
         await agent.store.remove_endpoint(endpoint_id)
         await agent._add_log(f"ENDPOINT: {endpoint_id} DELETED", level="WARNING")
         return {"status": "deleted"}
 
     @router.post("/api/v1/registry/{endpoint_id}/priority")
     async def set_priority(endpoint_id: str, request: Request):
+        _check_admin_auth(request)
         data = await request.json()
         priority = data.get("priority", 0)
         all_endpoints = await agent.store.get_all()

--- a/proxy/routes/telemetry.py
+++ b/proxy/routes/telemetry.py
@@ -29,6 +29,24 @@ def _sanitize_log(log: dict) -> dict:
 def create_router(agent) -> APIRouter:
     router = APIRouter()
 
+    def _check_auth(request: Request):
+        """Enforce API key auth on sensitive streaming endpoints.
+
+        /api/v1/logs streams all application events including SECURITY-level
+        entries (blocked IPs, failed auth attempts, identity assertions, plugin
+        installs).  An unauthenticated subscriber gets a real-time recon feed
+        that reveals which keys are failing (to time attacks), which IPs are
+        blocked (to rotate), and user email addresses from IDENTITY log lines.
+        Auth is skipped only when explicitly disabled (development mode).
+        """
+        if not agent.config.get("server", {}).get("auth", {}).get("enabled", False):
+            return
+        auth_header = request.headers.get("Authorization", "")
+        token = auth_header.replace("Bearer ", "").strip()
+        valid_keys = agent._get_api_keys()
+        if not token or token not in valid_keys:
+            raise HTTPException(status_code=401, detail="Telemetry: Unauthorized")
+
     @router.get("/health")
     async def health():
         import time as _time
@@ -56,6 +74,7 @@ def create_router(agent) -> APIRouter:
 
     @router.get("/api/v1/logs")
     async def stream_logs(request: Request):
+        _check_auth(request)
         global _active_log_streams
         if _active_log_streams >= _MAX_SSE_CONNECTIONS:
             raise HTTPException(status_code=503, detail="Too many SSE connections")


### PR DESCRIPTION
## Round 8 Security Fixes

### Unauthenticated registry mutations (CRITICAL)
`POST /api/v1/registry/{id}/toggle`, `DELETE /api/v1/registry/{id}`, and `POST /api/v1/registry/{id}/priority` had no auth check. An unauthenticated attacker could disable all upstream endpoints (instant DoS) or set a malicious endpoint to highest priority to redirect traffic. Added `_check_admin_auth()` closure mirroring `admin.py`, `plugins.py`, `gdpr.py`.

`GET /api/v1/telemetry/stream` (SOC dashboard SSE) also had no auth — real-time event feed exposed to anyone.

### Unauthenticated /api/v1/logs SSE stream (MEDIUM)
Streams all application events including `SECURITY`-level entries: blocked IPs, failed auth attempts, IDENTITY assertions with user emails, plugin installs. An unauthenticated subscriber gets a real-time recon feed. Added auth check.

### Incomplete PII scrubber field list (MEDIUM)
`scrub_dict()` only matched 5 field names. Added frozenset `_SENSITIVE_FIELDS` covering: `access_token`, `refresh_token`, `id_token`, `client_secret`, `signing_key`, `private_key`, `credentials`, `x-api-key`, `x-auth-token`, `x-access-token`, and more. Also added Anthropic `sk-ant-...` key pattern to `PII_PATTERNS` (was OpenAI-only).

### OTLP exporter hardcoded insecure=True (LOW)
Spans may include auth headers and user identifiers. `insecure=True` forces plaintext gRPC for all remote collectors. Now only uses insecure for `localhost:` / `127.0.0.1:` endpoints; remote OTLP uses TLS by default.

## False positives rejected
- **ThreatLedger race**: asyncio cooperative scheduling, no `await` in `_record_and_check` → atomic
- **Identity JTI/nonce**: `exp` claim validated; JTI revocation requires distributed storage → enhancement, not vulnerability
- **Negative token counts**: requires attacker to control upstream provider → trusted backends
- **Config path traversal**: `config_path` from startup args, not user input → RCE prerequisite

## Test results
870 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)