### PR TITLE
Add `.venv` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ screenshot.png
 docs/CYBERAPI_INTEGRATION.md
 docs/ECOSYSTEM_MAP.md
 docs/INTEGRATION_ARCHITECTURE.md
+.venv


### PR DESCRIPTION
### FabGPT — l0-git remediation

**Gate:** `gitignore_coverage` · **Confidence:** deterministic

.gitignore does not cover `.venv`. Python bytecode and virtualenv directories are user-local and should never travel through git. Add `.venv` to your .gitignore.

Add `.venv` to .gitignore.

_Approved by a human before opening._

---
🤖 **FabGPT OS** · source `l0git` · model `deterministic` · task `46ac523a6c1c3bf1` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"46ac523a6c1c3bf1","source":"l0git","model":"deterministic","severity":"INFO","iterations":1,"inference_s":0.0,"triage":"INFO"} -->