### PR TITLE
Bump aiohttp to 3.14.0 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.46.0
 PyYAML==6.0.3
 
 # HTTP
-aiohttp==3.13.5
+aiohttp==3.14.0
 
 # Database
 aiosqlite==0.22.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.13.5` → `3.14.0`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** AIOHTTP is vulnerable to cross-origin redirect with per-request cookies CVE-2026-34993, CVE-2026-47265

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `e62f0a7101466de3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"e62f0a7101466de3","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->