### PR TITLE
Prevent XSS by escaping HTML in Card body

### DIFF
--- a/ui/src/ui/Card.ts
+++ b/ui/src/ui/Card.ts
@@ -53,7 +53,7 @@ export function createCard(opts: CardOptions = {}): HTMLElement {
         const bodyEl = document.createElement('div');
         bodyEl.className = 'p-4';
         if (typeof opts.body === 'string') {
-            bodyEl.innerHTML = opts.body;
+            bodyEl.textContent = opts.body;
         } else if (Array.isArray(opts.body)) {
             for (const child of opts.body) bodyEl.appendChild(child);
         } else {


### PR DESCRIPTION
### FabGPT — security

**File:** `ui/src/ui/Card.ts` (line 56)
**Class:** xss — detected: non-literal assigned to innerHTML

**Rationale:** The vulnerability occurs because opts.body can be an untrusted HTML string assigned directly to bodyEl.innerHTML, enabling script injection. The fix replaces innerHTML with textContent when the body is a string, ensuring HTML is rendered as plain text rather than executed.

_Static-detected, LLM-fixed; reviewed by a human before opening._

---
🤖 **FabGPT OS** · source `security` · model `qwen3-coder-next` · task `abd3d0326c867173` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"abd3d0326c867173","source":"security","model":"qwen3-coder-next","severity":"WARN","iterations":1,"inference_s":11.64,"triage":"WARN"} -->