### PR TITLE
Bump aiohttp to 3.14.1 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.46.0
 PyYAML==6.0.3
 
 # HTTP
-aiohttp==3.14.0
+aiohttp==3.14.1
 
 # Database
 aiosqlite==0.22.1


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `aiohttp` `3.14.0` → `3.14.1`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisories:** CVE-2026-54273, CVE-2026-54274, CVE-2026-54275, CVE-2026-54276, CVE-2026-54277, CVE-2026-54278, CVE-2026-54279, CVE-2026-54280

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `673da374272763a1` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"673da374272763a1","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->